### PR TITLE
Fix Moov libary validation error

### DIFF
--- a/fedWireMessage.go
+++ b/fedWireMessage.go
@@ -158,9 +158,6 @@ func (fwm *FEDWireMessage) verify() error {
 	if err := fwm.validateInstructingFI(); err != nil {
 		return err
 	}
-	if err := fwm.validateOriginatorToBeneficiary(); err != nil {
-		return err
-	}
 	if err := fwm.validateFIIntermediaryFI(); err != nil {
 		return err
 	}
@@ -1071,27 +1068,6 @@ func (fwm *FEDWireMessage) validateInstructingFI() error {
 		}
 		if fwm.OriginatorFI == nil {
 			return fieldError("OriginatorFI", ErrFieldRequired)
-		}
-		return nil
-	}
-	return nil
-}
-
-// If present, Beneficiary and Originator (or OriginatorOptionF if BusinessFunctionCode is CustomerTransferPlus) are mandatory.
-func (fwm *FEDWireMessage) validateOriginatorToBeneficiary() error {
-	if fwm.OriginatorToBeneficiary != nil {
-		if fwm.Beneficiary == nil {
-			return fieldError("Beneficiary", ErrFieldRequired)
-		}
-		switch fwm.BusinessFunctionCode.BusinessFunctionCode {
-		case CustomerTransferPlus:
-			if fwm.OriginatorOptionF == nil {
-				return fieldError("OriginatorOptionF", ErrFieldRequired)
-			}
-		default:
-			if fwm.Originator == nil {
-				return fieldError("Originator", ErrFieldRequired)
-			}
 		}
 		return nil
 	}

--- a/fedWiremessage_test.go
+++ b/fedWiremessage_test.go
@@ -197,43 +197,6 @@ func TestFEDWireMessage_validateInstructingFI(t *testing.T) {
 	require.EqualError(t, err, expected)
 }
 
-func TestNewFEDWireMessage_validateOriginatorToBeneficiary(t *testing.T) {
-	fwm := mockCustomerTransferData()
-	fwm.OriginatorToBeneficiary = mockOriginatorToBeneficiary()
-	fwm.BusinessFunctionCode.BusinessFunctionCode = CustomerTransfer
-
-	// Beneficiary required field check
-	err := fwm.validateOriginatorToBeneficiary()
-
-	expected := fieldError("Beneficiary", ErrFieldRequired).Error()
-	require.EqualError(t, err, expected)
-
-	fwm.Beneficiary = mockBeneficiary()
-
-	// Originator required Field check
-	err = fwm.validateOriginatorToBeneficiary()
-
-	expected = fieldError("Originator", ErrFieldRequired).Error()
-	require.EqualError(t, err, expected)
-
-	fwm.Originator = mockOriginator()
-	fwm.BusinessFunctionCode.BusinessFunctionCode = CustomerTransferPlus
-
-	// OriginatorOptionF required Field check
-	err = fwm.validateOriginatorToBeneficiary()
-
-	expected = fieldError("OriginatorOptionF", ErrFieldRequired).Error()
-	require.EqualError(t, err, expected)
-
-	// check beneficiary still required
-	fwm.Beneficiary = nil
-
-	err = fwm.validateOriginatorToBeneficiary()
-
-	expected = fieldError("Beneficiary", ErrFieldRequired).Error()
-	require.EqualError(t, err, expected)
-}
-
 func TestFEDWireMessage_validateFIIntermediaryFI(t *testing.T) {
 	fwm := mockCustomerTransferData()
 	fwm.FIIntermediaryFI = mockFIIntermediaryFI()


### PR DESCRIPTION
According to FAIM, `{6000}` tag is optional for all types of function codes, even when `{4200}` or `{5000}` is not there.