### PR TITLE
Fix validation on all FI's (but not originator/beneficiary)

### DIFF
--- a/beneficiaryFI.go
+++ b/beneficiaryFI.go
@@ -88,29 +88,33 @@ func (bfi *BeneficiaryFI) String() string {
 // Validate performs WIRE format rule checks on BeneficiaryFI and returns an error if not Validated
 // The first error encountered is returned and stops that parsing.
 func (bfi *BeneficiaryFI) Validate() error {
-	if err := bfi.fieldInclusion(); err != nil {
-		return err
-	}
 	if bfi.tag != TagBeneficiaryFI {
 		return fieldError("tag", ErrValidTagForType, bfi.tag)
 	}
-	if err := bfi.isIdentificationCode(bfi.FinancialInstitution.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, bfi.FinancialInstitution.IdentificationCode)
+
+	if bfi.FinancialInstitution.IdentificationCode != "" && bfi.FinancialInstitution.IdentificationCode != " " {
+		if err := bfi.fieldInclusion(); err != nil {
+			return err
+		}
+		if err := bfi.isIdentificationCode(bfi.FinancialInstitution.IdentificationCode); err != nil {
+			return fieldError("IdentificationCode", err, bfi.FinancialInstitution.IdentificationCode)
+		}
+		switch bfi.FinancialInstitution.IdentificationCode {
+		case
+			SWIFTBankIdentifierCode,
+			CHIPSParticipant,
+			DemandDepositAccountNumber,
+			FEDRoutingNumber,
+			CHIPSIdentifier:
+		default:
+			return fieldError("IdentificationCode", ErrIdentificationCode, bfi.FinancialInstitution.IdentificationCode)
+		}
+		if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Identifier); err != nil {
+			return fieldError("Identifier", err, bfi.FinancialInstitution.Identifier)
+		}
 	}
+
 	// Can only be these Identification Codes
-	switch bfi.FinancialInstitution.IdentificationCode {
-	case
-		SWIFTBankIdentifierCode,
-		CHIPSParticipant,
-		DemandDepositAccountNumber,
-		FEDRoutingNumber,
-		CHIPSIdentifier:
-	default:
-		return fieldError("IdentificationCode", ErrIdentificationCode, bfi.FinancialInstitution.IdentificationCode)
-	}
-	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, bfi.FinancialInstitution.Identifier)
-	}
 	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Name); err != nil {
 		return fieldError("Name", err, bfi.FinancialInstitution.Name)
 	}

--- a/beneficiaryIntermediaryFI.go
+++ b/beneficiaryIntermediaryFI.go
@@ -89,25 +89,31 @@ func (bifi *BeneficiaryIntermediaryFI) String() string {
 // The first error encountered is returned and stops that parsing.
 // If ID Code is present, Identifier is mandatory and vice versa.
 func (bifi *BeneficiaryIntermediaryFI) Validate() error {
-	if err := bifi.fieldInclusion(); err != nil {
-		return err
-	}
 	if bifi.tag != TagBeneficiaryIntermediaryFI {
 		return fieldError("tag", ErrValidTagForType, bifi.tag)
 	}
-	if err := bifi.isIdentificationCode(bifi.FinancialInstitution.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, bifi.FinancialInstitution.IdentificationCode)
+
+	if bifi.FinancialInstitution.Identifier != "" && bifi.FinancialInstitution.Identifier != " " {
+		if err := bifi.fieldInclusion(); err != nil {
+			return err
+		}
+
+		if err := bifi.isIdentificationCode(bifi.FinancialInstitution.IdentificationCode); err != nil {
+			return fieldError("IdentificationCode", err, bifi.FinancialInstitution.IdentificationCode)
+		}
+
+		// Can only be these Identification Codes
+		switch bifi.FinancialInstitution.IdentificationCode {
+		case
+			"B", "C", "D", "F", "U":
+		default:
+			return fieldError("IdentificationCode", ErrIdentificationCode, bifi.FinancialInstitution.IdentificationCode)
+		}
+		if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Identifier); err != nil {
+			return fieldError("Identifier", err, bifi.FinancialInstitution.Identifier)
+		}
 	}
-	// Can only be these Identification Codes
-	switch bifi.FinancialInstitution.IdentificationCode {
-	case
-		"B", "C", "D", "F", "U":
-	default:
-		return fieldError("IdentificationCode", ErrIdentificationCode, bifi.FinancialInstitution.IdentificationCode)
-	}
-	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, bifi.FinancialInstitution.Identifier)
-	}
+
 	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Name); err != nil {
 		return fieldError("Name", err, bifi.FinancialInstitution.Name)
 	}

--- a/beneficiaryIntermediaryFI.go
+++ b/beneficiaryIntermediaryFI.go
@@ -93,7 +93,7 @@ func (bifi *BeneficiaryIntermediaryFI) Validate() error {
 		return fieldError("tag", ErrValidTagForType, bifi.tag)
 	}
 
-	if bifi.FinancialInstitution.Identifier != "" && bifi.FinancialInstitution.Identifier != " " {
+	if bifi.FinancialInstitution.IdentificationCode != "" && bifi.FinancialInstitution.IdentificationCode != " " {
 		if err := bifi.fieldInclusion(); err != nil {
 			return err
 		}

--- a/instructingFI.go
+++ b/instructingFI.go
@@ -89,25 +89,30 @@ func (ifi *InstructingFI) String() string {
 // The first error encountered is returned and stops that parsing.
 // If ID Code is present, Identifier is mandatory and vice versa.
 func (ifi *InstructingFI) Validate() error {
-	if err := ifi.fieldInclusion(); err != nil {
-		return err
-	}
 	if ifi.tag != TagInstructingFI {
 		return fieldError("tag", ErrValidTagForType, ifi.tag)
 	}
-	if err := ifi.isIdentificationCode(ifi.FinancialInstitution.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, ifi.FinancialInstitution.IdentificationCode)
+
+	if ifi.FinancialInstitution.IdentificationCode != "" && ifi.FinancialInstitution.IdentificationCode != " " {
+		if err := ifi.fieldInclusion(); err != nil {
+			return err
+		}
+
+		if err := ifi.isIdentificationCode(ifi.FinancialInstitution.IdentificationCode); err != nil {
+			return fieldError("IdentificationCode", err, ifi.FinancialInstitution.IdentificationCode)
+		}
+		// Can only be these Identification Codes
+		switch ifi.FinancialInstitution.IdentificationCode {
+		case
+			"B", "C", "D", "F", "U":
+		default:
+			return fieldError("IdentificationCode", ErrIdentificationCode, ifi.FinancialInstitution.IdentificationCode)
+		}
+		if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Identifier); err != nil {
+			return fieldError("Identifier", err, ifi.FinancialInstitution.Identifier)
+		}
 	}
-	// Can only be these Identification Codes
-	switch ifi.FinancialInstitution.IdentificationCode {
-	case
-		"B", "C", "D", "F", "U":
-	default:
-		return fieldError("IdentificationCode", ErrIdentificationCode, ifi.FinancialInstitution.IdentificationCode)
-	}
-	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, ifi.FinancialInstitution.Identifier)
-	}
+
 	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Name); err != nil {
 		return fieldError("Name", err, ifi.FinancialInstitution.Name)
 	}


### PR DESCRIPTION
Fixes the following tags:
```
	TagBeneficiaryIntermediaryFI = "{4000}"
	TagBeneficiaryFI = "{4100}"
	TagInstructingFI = "{5200}"
```

We already fixed:
```
	TagOriginatorFI = "{5100}"
```

Leaving {4200} and {5000} out right now, if we have an issue with those we have bigger problems